### PR TITLE
File edit differences to the Server Activity Log

### DIFF
--- a/app/Http/Controllers/Api/Client/Servers/FileController.php
+++ b/app/Http/Controllers/Api/Client/Servers/FileController.php
@@ -8,6 +8,7 @@ use Everest\Facades\Activity;
 use Illuminate\Http\Response;
 use Illuminate\Http\JsonResponse;
 use Everest\Services\Nodes\NodeJWTService;
+use Everest\Services\Files\FileDiffService;
 use Everest\Repositories\Wings\DaemonFileRepository;
 use Everest\Transformers\Api\Client\FileObjectTransformer;
 use Everest\Http\Controllers\Api\Client\ClientApiController;
@@ -22,6 +23,7 @@ use Everest\Http\Requests\Api\Client\Servers\Files\CompressFilesRequest;
 use Everest\Http\Requests\Api\Client\Servers\Files\DecompressFilesRequest;
 use Everest\Http\Requests\Api\Client\Servers\Files\GetFileContentsRequest;
 use Everest\Http\Requests\Api\Client\Servers\Files\WriteFileContentRequest;
+use Everest\Http\Requests\Api\Client\Servers\Files\WriteFileWithDiffRequest;
 
 class FileController extends ClientApiController
 {
@@ -30,7 +32,8 @@ class FileController extends ClientApiController
      */
     public function __construct(
         private NodeJWTService $jwtService,
-        private DaemonFileRepository $fileRepository
+        private DaemonFileRepository $fileRepository,
+        private FileDiffService $diffService
     ) {
         parent::__construct();
     }
@@ -109,6 +112,41 @@ class FileController extends ClientApiController
         $this->fileRepository->setServer($server)->putContent($request->get('file'), $request->getContent());
 
         Activity::event('server:file.write')->property('file', $request->get('file'))->log();
+
+        return new JsonResponse([], Response::HTTP_NO_CONTENT);
+    }
+
+    /**
+     * Writes the contents of the specified file to the server with diff tracking.
+     * This endpoint accepts JSON with original and new content to calculate diffs.
+     *
+     * @throws \Everest\Exceptions\Http\Connection\DaemonConnectionException
+     */
+    public function writeWithDiff(WriteFileWithDiffRequest $request, Server $server): JsonResponse
+    {
+        $file = $request->input('file');
+        $content = $request->input('content');
+        $originalContent = $request->input('original_content', '');
+
+        // Write the new content to the file
+        $this->fileRepository->setServer($server)->putContent($file, $content);
+
+        // Build activity log with diff information if it's a text file
+        $activity = Activity::event('server:file.write')->property('file', $file);
+
+        if ($this->diffService->isTextFile($file) && $originalContent !== null) {
+            $diff = $this->diffService->calculateDiff($originalContent, $content, $file);
+            
+            $activity->property('diff', [
+                'additions' => $diff['additions'],
+                'deletions' => $diff['deletions'],
+                'hunks' => $diff['hunks'],
+                'is_new_file' => $diff['is_new_file'] ?? false,
+                'large_file' => $diff['large_file'] ?? false,
+            ]);
+        }
+
+        $activity->log();
 
         return new JsonResponse([], Response::HTTP_NO_CONTENT);
     }

--- a/app/Http/Requests/Api/Client/Servers/Files/WriteFileWithDiffRequest.php
+++ b/app/Http/Requests/Api/Client/Servers/Files/WriteFileWithDiffRequest.php
@@ -1,0 +1,32 @@
+<?php
+
+namespace Everest\Http\Requests\Api\Client\Servers\Files;
+
+use Everest\Models\Permission;
+use Everest\Contracts\Http\ClientPermissionsRequest;
+use Everest\Http\Requests\Api\Client\ClientApiRequest;
+
+class WriteFileWithDiffRequest extends ClientApiRequest implements ClientPermissionsRequest
+{
+    /**
+     * Returns the permissions string indicating which permission should be used to
+     * validate that the authenticated user has permission to perform this action against
+     * the given resource (server).
+     */
+    public function permission(): string
+    {
+        return Permission::ACTION_FILE_CREATE;
+    }
+
+    /**
+     * Validation rules for writing a file with diff tracking.
+     */
+    public function rules(): array
+    {
+        return [
+            'file' => 'required|string',
+            'content' => 'present|string',
+            'original_content' => 'nullable|string',
+        ];
+    }
+}

--- a/app/Services/Files/FileDiffService.php
+++ b/app/Services/Files/FileDiffService.php
@@ -1,0 +1,177 @@
+<?php
+
+namespace Everest\Services\Files;
+
+use SebastianBergmann\Diff\Differ;
+use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
+
+class FileDiffService
+{
+    /**
+     * Text file extensions that support diff comparison.
+     */
+    public const TEXT_EXTENSIONS = [
+        'txt', 'md', 'markdown', 'json', 'yaml', 'yml', 'xml',
+        'html', 'htm', 'css', 'scss', 'sass', 'less',
+        'js', 'jsx', 'ts', 'tsx', 'mjs', 'cjs',
+        'php', 'py', 'rb', 'java', 'c', 'cpp', 'h', 'hpp',
+        'cs', 'go', 'rs', 'swift', 'kt', 'scala',
+        'sh', 'bash', 'zsh', 'fish', 'ps1', 'bat', 'cmd',
+        'sql', 'lua', 'pl', 'pm', 'r', 'R',
+        'toml', 'ini', 'cfg', 'conf', 'config', 'env', 'properties',
+        'htaccess', 'gitignore', 'dockerignore', 'editorconfig',
+        'vue', 'svelte', 'astro',
+        'log', 'csv', 'tsv',
+        'Dockerfile', 'Makefile', 'Rakefile', 'Gemfile',
+        'gradle', 'sbt', 'pom',
+    ];
+
+    /**
+     * Maximum file size in bytes for diff calculation (1MB).
+     */
+    public const MAX_DIFF_SIZE = 1048576;
+
+    /**
+     * Check if a file is a text file based on its extension.
+     */
+    public function isTextFile(string $filename): bool
+    {
+        $extension = strtolower(pathinfo($filename, PATHINFO_EXTENSION));
+        $basename = basename($filename);
+
+        // Check if it's a common config file without extension
+        if (in_array($basename, ['Dockerfile', 'Makefile', 'Rakefile', 'Gemfile', '.env', '.gitignore', '.dockerignore', '.editorconfig', '.htaccess', '.pteroignore'])) {
+            return true;
+        }
+
+        return in_array($extension, self::TEXT_EXTENSIONS);
+    }
+
+    /**
+     * Calculate the diff between original and new content.
+     */
+    public function calculateDiff(string $originalContent, string $newContent, string $filename): array
+    {
+        // If either content is too large, skip detailed diff
+        if (strlen($originalContent) > self::MAX_DIFF_SIZE || strlen($newContent) > self::MAX_DIFF_SIZE) {
+            return $this->createLargeDiffSummary($originalContent, $newContent);
+        }
+
+        $originalLines = explode("\n", $originalContent);
+        $newLines = explode("\n", $newContent);
+
+        $builder = new UnifiedDiffOutputBuilder(
+            "--- a/{$filename}\n+++ b/{$filename}\n",
+            true
+        );
+        $differ = new Differ($builder);
+
+        $diff = $differ->diff($originalContent, $newContent);
+
+        // Calculate additions and deletions
+        $additions = 0;
+        $deletions = 0;
+
+        $diffLines = explode("\n", $diff);
+        foreach ($diffLines as $line) {
+            if (str_starts_with($line, '+') && !str_starts_with($line, '+++')) {
+                $additions++;
+            } elseif (str_starts_with($line, '-') && !str_starts_with($line, '---')) {
+                $deletions++;
+            }
+        }
+
+        // Create a summary of changes
+        $hunks = $this->parseHunks($diff);
+
+        return [
+            'file' => $filename,
+            'additions' => $additions,
+            'deletions' => $deletions,
+            'diff' => $diff,
+            'hunks' => $hunks,
+            'original_lines' => count($originalLines),
+            'new_lines' => count($newLines),
+            'is_new_file' => empty(trim($originalContent)),
+        ];
+    }
+
+    /**
+     * Create a summary for large files where detailed diff is not practical.
+     */
+    private function createLargeDiffSummary(string $originalContent, string $newContent): array
+    {
+        $originalLines = substr_count($originalContent, "\n") + 1;
+        $newLines = substr_count($newContent, "\n") + 1;
+
+        return [
+            'additions' => max(0, $newLines - $originalLines),
+            'deletions' => max(0, $originalLines - $newLines),
+            'diff' => null,
+            'hunks' => [],
+            'original_lines' => $originalLines,
+            'new_lines' => $newLines,
+            'large_file' => true,
+        ];
+    }
+
+    /**
+     * Parse diff output into hunks for easier frontend rendering.
+     */
+    private function parseHunks(string $diff): array
+    {
+        $lines = explode("\n", $diff);
+        $hunks = [];
+        $currentHunk = null;
+
+        foreach ($lines as $line) {
+            // Skip header lines
+            if (str_starts_with($line, '---') || str_starts_with($line, '+++')) {
+                continue;
+            }
+
+            // New hunk
+            if (preg_match('/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/', $line, $matches)) {
+                if ($currentHunk !== null) {
+                    $hunks[] = $currentHunk;
+                }
+
+                $currentHunk = [
+                    'old_start' => (int) $matches[1],
+                    'old_lines' => isset($matches[2]) ? (int) $matches[2] : 1,
+                    'new_start' => (int) $matches[3],
+                    'new_lines' => isset($matches[4]) ? (int) $matches[4] : 1,
+                    'context' => trim($matches[5] ?? ''),
+                    'changes' => [],
+                ];
+                continue;
+            }
+
+            if ($currentHunk !== null) {
+                $type = 'context';
+                $content = $line;
+
+                if (str_starts_with($line, '+')) {
+                    $type = 'addition';
+                    $content = substr($line, 1);
+                } elseif (str_starts_with($line, '-')) {
+                    $type = 'deletion';
+                    $content = substr($line, 1);
+                } elseif (str_starts_with($line, ' ')) {
+                    $content = substr($line, 1);
+                }
+
+                $currentHunk['changes'][] = [
+                    'type' => $type,
+                    'content' => $content,
+                ];
+            }
+        }
+
+        if ($currentHunk !== null) {
+            $hunks[] = $currentHunk;
+        }
+
+        return $hunks;
+    }
+}

--- a/app/Services/Files/FileDiffService.php
+++ b/app/Services/Files/FileDiffService.php
@@ -2,9 +2,6 @@
 
 namespace Everest\Services\Files;
 
-use SebastianBergmann\Diff\Differ;
-use SebastianBergmann\Diff\Output\UnifiedDiffOutputBuilder;
-
 class FileDiffService
 {
     /**
@@ -30,6 +27,11 @@ class FileDiffService
      * Maximum file size in bytes for diff calculation (1MB).
      */
     public const MAX_DIFF_SIZE = 1048576;
+
+    /**
+     * Maximum number of lines for detailed diff (for performance).
+     */
+    public const MAX_DIFF_LINES = 5000;
 
     /**
      * Check if a file is a text file based on its extension.
@@ -60,35 +62,31 @@ class FileDiffService
         $originalLines = explode("\n", $originalContent);
         $newLines = explode("\n", $newContent);
 
-        $builder = new UnifiedDiffOutputBuilder(
-            "--- a/{$filename}\n+++ b/{$filename}\n",
-            true
-        );
-        $differ = new Differ($builder);
-
-        $diff = $differ->diff($originalContent, $newContent);
-
-        // Calculate additions and deletions
-        $additions = 0;
-        $deletions = 0;
-
-        $diffLines = explode("\n", $diff);
-        foreach ($diffLines as $line) {
-            if (str_starts_with($line, '+') && !str_starts_with($line, '+++')) {
-                $additions++;
-            } elseif (str_starts_with($line, '-') && !str_starts_with($line, '---')) {
-                $deletions++;
-            }
+        // If too many lines, skip detailed diff
+        if (count($originalLines) > self::MAX_DIFF_LINES || count($newLines) > self::MAX_DIFF_LINES) {
+            return $this->createLargeDiffSummary($originalContent, $newContent);
         }
 
-        // Create a summary of changes
-        $hunks = $this->parseHunks($diff);
+        // Calculate the diff using Myers algorithm (simplified LCS-based approach)
+        $hunks = $this->computeHunks($originalLines, $newLines);
+
+        // Count additions and deletions
+        $additions = 0;
+        $deletions = 0;
+        foreach ($hunks as $hunk) {
+            foreach ($hunk['changes'] as $change) {
+                if ($change['type'] === 'addition') {
+                    $additions++;
+                } elseif ($change['type'] === 'deletion') {
+                    $deletions++;
+                }
+            }
+        }
 
         return [
             'file' => $filename,
             'additions' => $additions,
             'deletions' => $deletions,
-            'diff' => $diff,
             'hunks' => $hunks,
             'original_lines' => count($originalLines),
             'new_lines' => count($newLines),
@@ -107,7 +105,6 @@ class FileDiffService
         return [
             'additions' => max(0, $newLines - $originalLines),
             'deletions' => max(0, $originalLines - $newLines),
-            'diff' => null,
             'hunks' => [],
             'original_lines' => $originalLines,
             'new_lines' => $newLines,
@@ -116,60 +113,226 @@ class FileDiffService
     }
 
     /**
-     * Parse diff output into hunks for easier frontend rendering.
+     * Compute diff hunks between two arrays of lines.
      */
-    private function parseHunks(string $diff): array
+    private function computeHunks(array $oldLines, array $newLines): array
     {
-        $lines = explode("\n", $diff);
-        $hunks = [];
-        $currentHunk = null;
+        $lcs = $this->longestCommonSubsequence($oldLines, $newLines);
+        $changes = $this->buildChangeList($oldLines, $newLines, $lcs);
+        
+        return $this->groupChangesIntoHunks($changes, $oldLines, $newLines);
+    }
 
-        foreach ($lines as $line) {
-            // Skip header lines
-            if (str_starts_with($line, '---') || str_starts_with($line, '+++')) {
-                continue;
-            }
-
-            // New hunk
-            if (preg_match('/^@@ -(\d+)(?:,(\d+))? \+(\d+)(?:,(\d+))? @@(.*)$/', $line, $matches)) {
-                if ($currentHunk !== null) {
-                    $hunks[] = $currentHunk;
+    /**
+     * Compute the Longest Common Subsequence between two arrays.
+     */
+    private function longestCommonSubsequence(array $old, array $new): array
+    {
+        $oldLen = count($old);
+        $newLen = count($new);
+        
+        // Build LCS length table
+        $lengths = array_fill(0, $oldLen + 1, array_fill(0, $newLen + 1, 0));
+        
+        for ($i = 1; $i <= $oldLen; $i++) {
+            for ($j = 1; $j <= $newLen; $j++) {
+                if ($old[$i - 1] === $new[$j - 1]) {
+                    $lengths[$i][$j] = $lengths[$i - 1][$j - 1] + 1;
+                } else {
+                    $lengths[$i][$j] = max($lengths[$i - 1][$j], $lengths[$i][$j - 1]);
                 }
-
-                $currentHunk = [
-                    'old_start' => (int) $matches[1],
-                    'old_lines' => isset($matches[2]) ? (int) $matches[2] : 1,
-                    'new_start' => (int) $matches[3],
-                    'new_lines' => isset($matches[4]) ? (int) $matches[4] : 1,
-                    'context' => trim($matches[5] ?? ''),
-                    'changes' => [],
-                ];
-                continue;
-            }
-
-            if ($currentHunk !== null) {
-                $type = 'context';
-                $content = $line;
-
-                if (str_starts_with($line, '+')) {
-                    $type = 'addition';
-                    $content = substr($line, 1);
-                } elseif (str_starts_with($line, '-')) {
-                    $type = 'deletion';
-                    $content = substr($line, 1);
-                } elseif (str_starts_with($line, ' ')) {
-                    $content = substr($line, 1);
-                }
-
-                $currentHunk['changes'][] = [
-                    'type' => $type,
-                    'content' => $content,
-                ];
             }
         }
 
+        // Backtrack to find LCS with positions
+        $lcs = [];
+        $i = $oldLen;
+        $j = $newLen;
+        
+        while ($i > 0 && $j > 0) {
+            if ($old[$i - 1] === $new[$j - 1]) {
+                array_unshift($lcs, ['old' => $i - 1, 'new' => $j - 1, 'line' => $old[$i - 1]]);
+                $i--;
+                $j--;
+            } elseif ($lengths[$i - 1][$j] > $lengths[$i][$j - 1]) {
+                $i--;
+            } else {
+                $j--;
+            }
+        }
+
+        return $lcs;
+    }
+
+    /**
+     * Build a list of changes (additions, deletions, unchanged) from the LCS.
+     */
+    private function buildChangeList(array $oldLines, array $newLines, array $lcs): array
+    {
+        $changes = [];
+        $oldIdx = 0;
+        $newIdx = 0;
+        $lcsIdx = 0;
+
+        while ($oldIdx < count($oldLines) || $newIdx < count($newLines)) {
+            if ($lcsIdx < count($lcs)) {
+                $lcsItem = $lcs[$lcsIdx];
+                
+                // Add deletions (lines in old but not in LCS)
+                while ($oldIdx < $lcsItem['old']) {
+                    $changes[] = [
+                        'type' => 'deletion',
+                        'content' => $oldLines[$oldIdx],
+                        'old_line' => $oldIdx + 1,
+                        'new_line' => null,
+                    ];
+                    $oldIdx++;
+                }
+                
+                // Add additions (lines in new but not in LCS)
+                while ($newIdx < $lcsItem['new']) {
+                    $changes[] = [
+                        'type' => 'addition',
+                        'content' => $newLines[$newIdx],
+                        'old_line' => null,
+                        'new_line' => $newIdx + 1,
+                    ];
+                    $newIdx++;
+                }
+                
+                // Add unchanged line
+                $changes[] = [
+                    'type' => 'context',
+                    'content' => $lcsItem['line'],
+                    'old_line' => $oldIdx + 1,
+                    'new_line' => $newIdx + 1,
+                ];
+                $oldIdx++;
+                $newIdx++;
+                $lcsIdx++;
+            } else {
+                // Handle remaining lines after LCS is exhausted
+                while ($oldIdx < count($oldLines)) {
+                    $changes[] = [
+                        'type' => 'deletion',
+                        'content' => $oldLines[$oldIdx],
+                        'old_line' => $oldIdx + 1,
+                        'new_line' => null,
+                    ];
+                    $oldIdx++;
+                }
+                while ($newIdx < count($newLines)) {
+                    $changes[] = [
+                        'type' => 'addition',
+                        'content' => $newLines[$newIdx],
+                        'old_line' => null,
+                        'new_line' => $newIdx + 1,
+                    ];
+                    $newIdx++;
+                }
+            }
+        }
+
+        return $changes;
+    }
+
+    /**
+     * Group changes into hunks with context lines.
+     */
+    private function groupChangesIntoHunks(array $changes, array $oldLines, array $newLines, int $contextLines = 3): array
+    {
+        if (empty($changes)) {
+            return [];
+        }
+
+        $hunks = [];
+        $currentHunk = null;
+        $lastChangeIdx = -1;
+
+        foreach ($changes as $idx => $change) {
+            $isChange = $change['type'] !== 'context';
+            
+            if ($isChange) {
+                if ($currentHunk === null) {
+                    // Start new hunk with context before
+                    $contextStart = max(0, $idx - $contextLines);
+                    $currentHunk = [
+                        'old_start' => null,
+                        'old_lines' => 0,
+                        'new_start' => null,
+                        'new_lines' => 0,
+                        'context' => '',
+                        'changes' => [],
+                    ];
+                    
+                    // Add context lines before the change
+                    for ($i = $contextStart; $i < $idx; $i++) {
+                        $ctx = $changes[$i];
+                        if ($currentHunk['old_start'] === null && $ctx['old_line'] !== null) {
+                            $currentHunk['old_start'] = $ctx['old_line'];
+                        }
+                        if ($currentHunk['new_start'] === null && $ctx['new_line'] !== null) {
+                            $currentHunk['new_start'] = $ctx['new_line'];
+                        }
+                        $currentHunk['changes'][] = [
+                            'type' => 'context',
+                            'content' => $ctx['content'],
+                        ];
+                        if ($ctx['old_line'] !== null) $currentHunk['old_lines']++;
+                        if ($ctx['new_line'] !== null) $currentHunk['new_lines']++;
+                    }
+                }
+                
+                // Set start positions if not set
+                if ($currentHunk['old_start'] === null) {
+                    $currentHunk['old_start'] = $change['old_line'] ?? 1;
+                }
+                if ($currentHunk['new_start'] === null) {
+                    $currentHunk['new_start'] = $change['new_line'] ?? 1;
+                }
+                
+                // Add the change
+                $currentHunk['changes'][] = [
+                    'type' => $change['type'],
+                    'content' => $change['content'],
+                ];
+                if ($change['type'] === 'deletion') {
+                    $currentHunk['old_lines']++;
+                } elseif ($change['type'] === 'addition') {
+                    $currentHunk['new_lines']++;
+                }
+                
+                $lastChangeIdx = $idx;
+            } elseif ($currentHunk !== null) {
+                // Context line after a change
+                $distanceFromLastChange = $idx - $lastChangeIdx;
+                
+                if ($distanceFromLastChange <= $contextLines * 2) {
+                    // Within context range, add to current hunk
+                    $currentHunk['changes'][] = [
+                        'type' => 'context',
+                        'content' => $change['content'],
+                    ];
+                    $currentHunk['old_lines']++;
+                    $currentHunk['new_lines']++;
+                } else {
+                    // Too far from last change, close current hunk
+                    // But first add trailing context
+                    $hunks[] = $currentHunk;
+                    $currentHunk = null;
+                }
+            }
+        }
+
+        // Don't forget the last hunk
         if ($currentHunk !== null) {
             $hunks[] = $currentHunk;
+        }
+
+        // Ensure all hunks have valid start positions
+        foreach ($hunks as &$hunk) {
+            if ($hunk['old_start'] === null) $hunk['old_start'] = 1;
+            if ($hunk['new_start'] === null) $hunk['new_start'] = 1;
         }
 
         return $hunks;

--- a/resources/lang/en/activity.php
+++ b/resources/lang/en/activity.php
@@ -79,7 +79,7 @@ return [
             'pull' => 'Downloaded a remote file from :url to :directory',
             'rename_one' => 'Renamed :directory:files.0.from to :directory:files.0.to',
             'rename_other' => 'Renamed :count files in :directory',
-            'write' => 'Wrote new content to :file',
+            'write' => 'Modified :file',
             'upload' => 'Began a file upload',
             'uploaded' => 'Uploaded :directory:file',
         ],

--- a/resources/scripts/api/routes/server/files.ts
+++ b/resources/scripts/api/routes/server/files.ts
@@ -79,13 +79,23 @@ const renameFiles = (uuid: string, directory: string, files: { to: string; from:
     });
 };
 
-const saveFileContents = async (uuid: string, file: string, content: string): Promise<void> => {
-    await http.post(`/api/client/servers/${uuid}/files/write`, content, {
-        params: { file },
-        headers: {
-            'Content-Type': 'text/plain',
-        },
-    });
+const saveFileContents = async (uuid: string, file: string, content: string, originalContent?: string): Promise<void> => {
+    // Use the new endpoint with diff tracking when originalContent is provided
+    if (originalContent !== undefined) {
+        await http.post(`/api/client/servers/${uuid}/files/write-with-diff`, {
+            file,
+            content,
+            original_content: originalContent,
+        });
+    } else {
+        // Fallback to the old endpoint for backward compatibility
+        await http.post(`/api/client/servers/${uuid}/files/write`, content, {
+            params: { file },
+            headers: {
+                'Content-Type': 'text/plain',
+            },
+        });
+    }
 };
 
 const deleteFiles = (uuid: string, directory: string, files: string[]): Promise<void> => {

--- a/resources/scripts/components/server/files/FileEditContainer.tsx
+++ b/resources/scripts/components/server/files/FileEditContainer.tsx
@@ -27,6 +27,7 @@ export default () => {
     const { action, '*': rawFilename } = useParams<{ action: 'edit' | 'new'; '*': string }>();
     const [loading, setLoading] = useState(action === 'edit');
     const [content, setContent] = useState('');
+    const [originalContent, setOriginalContent] = useState('');
     const [modalVisible, setModalVisible] = useState(false);
     const [language, setLanguage] = useState<LanguageDescription>();
 
@@ -58,7 +59,10 @@ export default () => {
         setLoading(true);
         setDirectory(dirname(filename));
         getFileContents(uuid, filename)
-            .then(setContent)
+            .then(fileContent => {
+                setContent(fileContent);
+                setOriginalContent(fileContent);
+            })
             .catch(error => {
                 console.error(error);
                 setError(httpErrorToHuman(error));
@@ -74,7 +78,14 @@ export default () => {
         setLoading(true);
         clearFlashes('files:view');
         fetchFileContent()
-            .then(content => saveFileContents(uuid, name ?? filename, content))
+            .then(newContent => {
+                // Pass original content for diff calculation (use empty string for new files)
+                const original = action === 'new' ? '' : originalContent;
+                return saveFileContents(uuid, name ?? filename, newContent, original).then(() => {
+                    // Update original content after successful save
+                    setOriginalContent(newContent);
+                });
+            })
             .then(() => {
                 if (name) {
                     navigate(`/server/${id}/files/edit/${encodePathSegments(name)}`);

--- a/resources/scripts/elements/activity/ActivityLogEntry.tsx
+++ b/resources/scripts/elements/activity/ActivityLogEntry.tsx
@@ -5,6 +5,7 @@ import Translate from '@/elements/Translate';
 import { format, formatDistanceToNowStrict } from 'date-fns';
 import { ActivityLog } from '@definitions/account';
 import ActivityLogMetaButton from '@/elements/activity/ActivityLogMetaButton';
+import FileDiffViewer, { FileDiff } from '@/elements/activity/FileDiffViewer';
 import { FolderOpenIcon, TerminalIcon } from '@heroicons/react/solid';
 import classNames from 'classnames';
 import style from './style.module.css';
@@ -39,11 +40,32 @@ function wrapProperties(value: unknown): any {
     return value;
 }
 
+function hasFileDiff(activity: ActivityLog): boolean {
+    return activity.event === 'server:file.write' && 
+        activity.properties?.diff !== undefined &&
+        typeof activity.properties.diff === 'object';
+}
+
+function getFileDiff(activity: ActivityLog): FileDiff | null {
+    if (!hasFileDiff(activity)) return null;
+    
+    const diff = activity.properties.diff as Record<string, unknown>;
+    return {
+        file: activity.properties.file as string | undefined,
+        additions: (diff.additions as number) || 0,
+        deletions: (diff.deletions as number) || 0,
+        hunks: (diff.hunks as FileDiff['hunks']) || [],
+        is_new_file: (diff.is_new_file as boolean) || false,
+        large_file: (diff.large_file as boolean) || false,
+    };
+}
+
 export default ({ activity, children }: Props) => {
     const { pathTo } = useLocationHash();
     const actor = activity.relationships.actor;
     const properties = wrapProperties(activity.properties);
     const { colors } = useStoreState(state => state.theme.data!);
+    const fileDiff = getFileDiff(activity);
 
     return (
         <div
@@ -55,51 +77,66 @@ export default ({ activity, children }: Props) => {
                     <Avatar name={actor?.uuid || 'system'} />
                 </div>
             </div>
-            <div className={'col-span-10 flex sm:col-span-9'}>
-                <div className={'flex-1 px-4 sm:px-0'}>
-                    <div className={'flex items-center text-slate-50'}>
-                        <Tooltip placement={'top'} content={actor?.email || 'System User'}>
-                            <span className={'font-bold'}>{actor?.username || 'System'}</span>
-                        </Tooltip>
-                        <span className={'text-slate-400 mx-2'}>&bull;</span>
-                        <Link
-                            to={`#${pathTo({ event: activity.event })}`}
-                            className={
-                                'text-gray-300 transition-colors duration-75 hover:text-cyan-400 active:text-cyan-400'
-                            }
-                        >
-                            {activity.description ?? activity.event}
-                        </Link>
-                        <div className={classNames(style.icons, 'group-hover:text-slate-300')}>
-                            {activity.isApi && (
-                                <Tooltip placement={'top'} content={'Using API Key'}>
-                                    <TerminalIcon />
-                                </Tooltip>
+            <div className={'col-span-10 flex flex-col sm:col-span-9'}>
+                <div className={'flex'}>
+                    <div className={'flex-1 px-4 sm:px-0'}>
+                        <div className={'flex items-center text-slate-50'}>
+                            <Tooltip placement={'top'} content={actor?.email || 'System User'}>
+                                <span className={'font-bold'}>{actor?.username || 'System'}</span>
+                            </Tooltip>
+                            <span className={'text-slate-400 mx-2'}>&bull;</span>
+                            <Link
+                                to={`#${pathTo({ event: activity.event })}`}
+                                className={
+                                    'text-gray-300 transition-colors duration-75 hover:text-cyan-400 active:text-cyan-400'
+                                }
+                            >
+                                {activity.description ?? activity.event}
+                            </Link>
+                            <div className={classNames(style.icons, 'group-hover:text-slate-300')}>
+                                {activity.isApi && (
+                                    <Tooltip placement={'top'} content={'Using API Key'}>
+                                        <TerminalIcon />
+                                    </Tooltip>
+                                )}
+                                {activity.event.startsWith('server:sftp.') && (
+                                    <Tooltip placement={'top'} content={'Using SFTP'}>
+                                        <FolderOpenIcon />
+                                    </Tooltip>
+                                )}
+                                {children}
+                            </div>
+                        </div>
+                        <p className={style.description}>
+                            <Translate ns={'activity'} values={properties} i18nKey={activity.event.replace(':', '.')} />
+                        </p>
+                        {fileDiff && (
+                            <div className="mt-2 text-xs text-slate-400">
+                                <span className="text-green-400">+{fileDiff.additions}</span>
+                                <span className="mx-1">/</span>
+                                <span className="text-red-400">-{fileDiff.deletions}</span>
+                                <span className="ml-1">lines changed</span>
+                            </div>
+                        )}
+                        <div className={'mt-1 flex items-center text-sm'}>
+                            {activity.ip && (
+                                <span>
+                                    {activity.ip}
+                                    <span className={'text-slate-400'}>&nbsp;|&nbsp;</span>
+                                </span>
                             )}
-                            {activity.event.startsWith('server:sftp.') && (
-                                <Tooltip placement={'top'} content={'Using SFTP'}>
-                                    <FolderOpenIcon />
-                                </Tooltip>
-                            )}
-                            {children}
+                            <Tooltip placement={'right'} content={format(activity.timestamp, 'MMM do, yyyy H:mm:ss')}>
+                                <span>{formatDistanceToNowStrict(activity.timestamp, { addSuffix: true })}</span>
+                            </Tooltip>
                         </div>
                     </div>
-                    <p className={style.description}>
-                        <Translate ns={'activity'} values={properties} i18nKey={activity.event.replace(':', '.')} />
-                    </p>
-                    <div className={'mt-1 flex items-center text-sm'}>
-                        {activity.ip && (
-                            <span>
-                                {activity.ip}
-                                <span className={'text-slate-400'}>&nbsp;|&nbsp;</span>
-                            </span>
-                        )}
-                        <Tooltip placement={'right'} content={format(activity.timestamp, 'MMM do, yyyy H:mm:ss')}>
-                            <span>{formatDistanceToNowStrict(activity.timestamp, { addSuffix: true })}</span>
-                        </Tooltip>
-                    </div>
+                    {activity.hasAdditionalMetadata && <ActivityLogMetaButton meta={activity.properties} />}
                 </div>
-                {activity.hasAdditionalMetadata && <ActivityLogMetaButton meta={activity.properties} />}
+                {fileDiff && (
+                    <div className="mt-3 px-4 sm:px-0">
+                        <FileDiffViewer diff={fileDiff} />
+                    </div>
+                )}
             </div>
         </div>
     );

--- a/resources/scripts/elements/activity/FileDiffViewer.tsx
+++ b/resources/scripts/elements/activity/FileDiffViewer.tsx
@@ -1,0 +1,200 @@
+import { useState } from 'react';
+import classNames from 'classnames';
+import { ChevronDownIcon, ChevronRightIcon } from '@heroicons/react/solid';
+
+interface DiffChange {
+    type: 'addition' | 'deletion' | 'context';
+    content: string;
+}
+
+interface DiffHunk {
+    old_start: number;
+    old_lines: number;
+    new_start: number;
+    new_lines: number;
+    context: string;
+    changes: DiffChange[];
+}
+
+export interface FileDiff {
+    file?: string;
+    additions: number;
+    deletions: number;
+    hunks: DiffHunk[];
+    is_new_file?: boolean;
+    large_file?: boolean;
+}
+
+interface Props {
+    diff: FileDiff;
+    filename?: string;
+    className?: string;
+}
+
+const DiffStats = ({ additions, deletions }: { additions: number; deletions: number }) => (
+    <div className="flex items-center gap-2 text-sm">
+        <span className="text-green-400 font-mono">+{additions}</span>
+        <span className="text-red-400 font-mono">-{deletions}</span>
+    </div>
+);
+
+interface DiffLineProps {
+    change: DiffChange;
+    lineNumber?: number;
+}
+
+const DiffLine = ({ change, lineNumber }: DiffLineProps) => {
+    const getBgColor = () => {
+        switch (change.type) {
+            case 'addition':
+                return 'bg-green-900/30 border-l-2 border-green-500';
+            case 'deletion':
+                return 'bg-red-900/30 border-l-2 border-red-500';
+            default:
+                return 'bg-transparent border-l-2 border-transparent';
+        }
+    };
+
+    const getLinePrefix = () => {
+        switch (change.type) {
+            case 'addition':
+                return '+';
+            case 'deletion':
+                return '-';
+            default:
+                return ' ';
+        }
+    };
+
+    return (
+        <div className={classNames('flex', getBgColor())}>
+            <span className="w-12 px-2 text-right text-slate-500 text-xs font-mono select-none border-r border-slate-700">
+                {lineNumber ?? ''}
+            </span>
+            <span
+                className={classNames(
+                    'w-6 text-center text-xs font-mono select-none',
+                    change.type === 'addition' && 'text-green-400',
+                    change.type === 'deletion' && 'text-red-400',
+                    change.type === 'context' && 'text-slate-500'
+                )}
+            >
+                {getLinePrefix()}
+            </span>
+            <pre className="flex-1 text-xs font-mono px-2 whitespace-pre-wrap break-all text-slate-300">
+                {change.content || '\u00A0'}
+            </pre>
+        </div>
+    );
+};
+
+const DiffHunkView = ({ hunk, index }: { hunk: DiffHunk; index: number }) => {
+    const [expanded, setExpanded] = useState(true);
+
+    let oldLineNum = hunk.old_start;
+    let newLineNum = hunk.new_start;
+
+    return (
+        <div className="border border-slate-700 rounded mb-2 overflow-hidden">
+            <button
+                className="w-full flex items-center gap-2 px-3 py-2 bg-slate-800 hover:bg-slate-700 text-sm text-slate-400 font-mono"
+                onClick={() => setExpanded(!expanded)}
+            >
+                {expanded ? (
+                    <ChevronDownIcon className="h-4 w-4" />
+                ) : (
+                    <ChevronRightIcon className="h-4 w-4" />
+                )}
+                <span>
+                    @@ -{hunk.old_start},{hunk.old_lines} +{hunk.new_start},{hunk.new_lines} @@
+                </span>
+                {hunk.context && <span className="text-slate-500 truncate">{hunk.context}</span>}
+            </button>
+
+            {expanded && (
+                <div className="bg-slate-900">
+                    {hunk.changes.map((change, idx) => {
+                        let lineNum: number | undefined;
+
+                        if (change.type === 'deletion') {
+                            lineNum = oldLineNum++;
+                        } else if (change.type === 'addition') {
+                            lineNum = newLineNum++;
+                        } else {
+                            lineNum = newLineNum++;
+                            oldLineNum++;
+                        }
+
+                        return <DiffLine key={`${index}-${idx}`} change={change} lineNumber={lineNum} />;
+                    })}
+                </div>
+            )}
+        </div>
+    );
+};
+
+export default ({ diff, filename, className }: Props) => {
+    const [showDiff, setShowDiff] = useState(false);
+    const displayFilename = filename || diff.file || 'Unknown file';
+
+    if (diff.large_file) {
+        return (
+            <div className={classNames('rounded-lg bg-slate-800 p-4', className)}>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <span className="text-sm text-slate-300 font-mono truncate">{displayFilename}</span>
+                        <DiffStats additions={diff.additions} deletions={diff.deletions} />
+                    </div>
+                    <span className="text-xs text-slate-500">File too large for detailed diff</span>
+                </div>
+            </div>
+        );
+    }
+
+    if (!diff.hunks || diff.hunks.length === 0) {
+        return (
+            <div className={classNames('rounded-lg bg-slate-800 p-4', className)}>
+                <div className="flex items-center justify-between">
+                    <div className="flex items-center gap-3">
+                        <span className="text-sm text-slate-300 font-mono truncate">{displayFilename}</span>
+                        {diff.is_new_file ? (
+                            <span className="text-xs text-green-400 bg-green-900/30 px-2 py-0.5 rounded">New file</span>
+                        ) : (
+                            <DiffStats additions={diff.additions} deletions={diff.deletions} />
+                        )}
+                    </div>
+                </div>
+            </div>
+        );
+    }
+
+    return (
+        <div className={classNames('rounded-lg bg-slate-800 overflow-hidden', className)}>
+            <button
+                className="w-full flex items-center justify-between p-3 hover:bg-slate-700 transition-colors"
+                onClick={() => setShowDiff(!showDiff)}
+            >
+                <div className="flex items-center gap-3">
+                    {showDiff ? (
+                        <ChevronDownIcon className="h-5 w-5 text-slate-400" />
+                    ) : (
+                        <ChevronRightIcon className="h-5 w-5 text-slate-400" />
+                    )}
+                    <span className="text-sm text-slate-300 font-mono truncate">{displayFilename}</span>
+                    {diff.is_new_file && (
+                        <span className="text-xs text-green-400 bg-green-900/30 px-2 py-0.5 rounded">New file</span>
+                    )}
+                </div>
+                <DiffStats additions={diff.additions} deletions={diff.deletions} />
+            </button>
+
+            {showDiff && (
+                <div className="border-t border-slate-700 p-3">
+                    {diff.hunks.map((hunk, index) => (
+                        <DiffHunkView key={index} hunk={hunk} index={index} />
+                    ))}
+                </div>
+            )}
+        </div>
+    );
+};

--- a/routes/api-client.php
+++ b/routes/api-client.php
@@ -129,6 +129,7 @@ Route::prefix('/')->middleware([SuspendedAccount::class])->group(function () {
             Route::put('/rename', [Client\Servers\FileController::class, 'rename']);
             Route::post('/copy', [Client\Servers\FileController::class, 'copy']);
             Route::post('/write', [Client\Servers\FileController::class, 'write']);
+            Route::post('/write-with-diff', [Client\Servers\FileController::class, 'writeWithDiff']);
             Route::post('/compress', [Client\Servers\FileController::class, 'compress']);
             Route::post('/decompress', [Client\Servers\FileController::class, 'decompress']);
             Route::post('/delete', [Client\Servers\FileController::class, 'delete']);


### PR DESCRIPTION
This pull request improves the Server Activity Log by displaying detailed, review-friendly differences whenever a server owner or subuser edits a text-based file through the web editor. Each activity entry now records the exact file path and presents a structured summary of added and removed lines, with an expandable pull request style view of the changes.

**Key Changes**

Introduced a dedicated file write endpoint with change tracking ([/files/write-with-diff] to capture sufficient context for calculating differences between the original and updated content.
Implemented server-side calculation of file content differences for text files without relying on development-only dependencies, ensuring production compatibility.
Updated the client file editor save flow to send both the original content and the updated content, enabling accurate calculation of differences.
Enhanced the Activity Log interface to display line change statistics and a collapsible, hunk-based view of the differences for [server:file.write] events.
Added performance safeguards for large files by recording only summary information when detailed calculation is not practical.

**Compatibility Notes**

The existing [/files/write] endpoint remains unchanged and continues to be used as a fallback when original content is not provided.
Change tracking is currently intended for edits performed through the web editor; other write paths continue to operate normally without generating detailed differences.

Please review and make changes. I would love for this idea to be fully integrated.